### PR TITLE
Update validate challenge method to call Authsignal's validate endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in authsignal-ruby.gemspec
 gemspec
-
-gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    authsignal-ruby (1.0.1)
+    authsignal-ruby (1.0.2)
       httparty (~> 0.21.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ GEM
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    jwt (2.7.1)
     mini_mime (1.1.5)
     multi_xml (0.6.0)
     public_suffix (4.0.7)
@@ -45,7 +44,6 @@ PLATFORMS
 
 DEPENDENCIES
   authsignal-ruby!
-  jwt
   rake (~> 13.0)
   rspec (~> 3.2)
   webmock (~> 3.14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    authsignal-ruby (1.0.2)
+    authsignal-ruby (2.0.0)
       httparty (~> 0.21.0)
 
 GEM

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -1,5 +1,4 @@
 require "httparty"
-require 'jwt'
 
 require "authsignal/version"
 require "authsignal/client"

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -66,12 +66,8 @@ module Authsignal
 
         def validate_challenge(token:, user_id: nil)
             response = Client.new.validate_challenge(user_id: user_id, token: token)
-
-            state = response["state"]
-
-            success = state == "CHALLENGE_SUCCEEDED"
             
-            return { user_id: response["userId"], success: success, state: state, action: response["actionCode"] }
+            return { user_id: response["userId"], is_valid: response["isValid"], state: response["state"], action: response["actionCode"] }
           end
 
         private

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -68,7 +68,7 @@ module Authsignal
             response = Client.new.validate_challenge(user_id: user_id, token: token)
             
             return { user_id: response["userId"], is_valid: response["isValid"], state: response["state"], action: response["actionCode"] }
-          end
+        end
 
         private
         def underscore(string)

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -47,7 +47,7 @@ module Authsignal
         def validate_challenge(user_id: nil, token:)
             path = "/validate"
 
-            response =  post("path", query: {}, body: { user_id: user_id, token: token }.to_json)
+            response =  post(path, query: {}, body: { user_id: user_id, token: token }.to_json)
             handle_response(response)
         end
 

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -47,7 +47,8 @@ module Authsignal
         def validate_challenge(user_id: nil, token:)
             path = "/validate"
 
-            response =  post(path, query: {}, body: { user_id: user_id, token: token }.to_json)
+            response =  post(path, query: {}, body: { userId: user_id, token: token }.to_json)
+
             handle_response(response)
         end
 

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -47,7 +47,7 @@ module Authsignal
         def validate_challenge(user_id: nil, token:)
             path = "/validate"
 
-            response =  post(path, query: {}, body: { userId: user_id, token: token }.to_json)
+            response = post(path, query: {}, body: { userId: user_id, token: token }.to_json)
 
             handle_response(response)
         end

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -37,6 +37,12 @@ module Authsignal
             get(path)
         end
 
+        def validate_challenge(user_id: nil, token:)
+            path = "/validate"
+
+            post(path, query: {}, body: { user_id: user_id, token: token }.to_json)
+        end
+
         def get_action(user_id, action_code, idempotency_key)
             get("/users/#{ERB::Util.url_encode(user_id)}/actions/#{action_code}/#{ERB::Util.url_encode(idempotency_key)}")
         end

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -4,6 +4,13 @@ module Authsignal
         NO_API_KEY_MESSAGE  = "No Authsignal API Secret Key Set"
         include HTTParty
 
+        def handle_response(response)
+            unless response.success?
+              raise HTTParty::ResponseError, "Failed with status code #{response.code}"
+            end
+            response
+        end
+
         def initialize
             self.class.base_uri Authsignal.configuration.base_uri
             @api_key = require_api_key
@@ -40,7 +47,8 @@ module Authsignal
         def validate_challenge(user_id: nil, token:)
             path = "/validate"
 
-            post(path, query: {}, body: { user_id: user_id, token: token }.to_json)
+            response =  post("path", query: {}, body: { user_id: user_id, token: token }.to_json)
+            handle_response(response)
         end
 
         def get_action(user_id, action_code, idempotency_key)

--- a/lib/authsignal/version.rb
+++ b/lib/authsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Authsignal
-  VERSION = "1.0.2"
+  VERSION = "2.0.0"
 end

--- a/lib/authsignal/version.rb
+++ b/lib/authsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Authsignal
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Authsignal do
 
       expect(response[:user_id]).to eq("legitimate_user_id")
       expect(response[:state]).to eq("CHALLENGE_SUCCEEDED")
-      expect(response[:success]).to eq(true)
+      expect(response[:is_valid]).to eq(true)
     end
 
     it "Checks that success is false when userId is incorrect" do
@@ -143,18 +143,18 @@ RSpec.describe Authsignal do
           'Content-Type'=>'application/json',
         })
       .to_return(
-        status: 200, 
+        status: 400, 
         body: {"error":"invalid_request","errorDescription":"The user is invalid."}.to_json, 
         headers: {'Content-Type' => 'application/json'}
       )
 
-      response = Authsignal.validate_challenge(
+      expect {
+        Authsignal.validate_challenge(
         user_id: "spoofed_user_id",
         token: "token",
       )
-
-      expect(response[:state]).to eq(nil)
-      expect(response[:success]).to eq(false)
+      }.to raise_error(HTTParty::ResponseError)
+      
     end
   end
 end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -106,38 +106,29 @@ RSpec.describe Authsignal do
   end
 
   describe "validate_challenge" do
-    before do
-      stub_request(:get, "http://localhost:8080/users/legitimate_user_id/actions/alwaysChallenge/a682af7d-c929-4c29-9c2a-71e69ab5c603")
-      .with(basic_auth: ['secret', ''])
-      .to_return(body: {success: true, state: "CHALLENGE_SUCCEEDED", user_id: "legitimate_user_id", stateUpdatedAt: "2022-07-25T03:19:00.316Z", createdAt: "2022-07-25T03:19:00.316Z"}.to_json,
-                status: 200,
-                headers: {'Content-Type' => 'application/json'})
-    end
-
-    payload = { 
-      "iat": Time.now.to_i, 
-      "sub": "legitimate_user_id", 
-      "exp": Time.now.to_i + 10 * 60, 
-      "iss": "https://challenge.authsignal.com/555159e4-adc3-454b-82b1-b55a2783f712", 
-      "aud": "https://challenge.authsignal.com/555159e4-adc3-454b-82b1-b55a2783f712", 
-      "scope": "read:authenticators add:authenticators update:authenticators remove:authenticators", 
-      "other": { 
-        "tenantId": "555159e4-adc3-454b-82b1-b55a2783f712", 
-        "publishableKey": "2fff14a6600b7a58170793109c78b876", 
-        "userId": "legitimate_user_id", 
-        "actionCode": "alwaysChallenge", 
-        "idempotencyKey": "a682af7d-c929-4c29-9c2a-71e69ab5c603" 
-      } 
-    }
-
-    hmac_secret = 'secret'
-
-    token = JWT.encode payload, hmac_secret, 'HS256'
-
     it "Checks that the challenge was successful when userId correct" do
+      stub_request(:post, "http://localhost:8080/validate")
+      .with(
+        headers: {
+          'Content-Type'=>'application/json',
+        })
+      .to_return(
+        status: 200, 
+        body: {
+          "isValid":true,
+          "state":"CHALLENGE_SUCCEEDED",
+          "stateUpdatedAt":"2024-04-11T22:30:52.317Z",
+          "userId":"legitimate_user_id",
+          "actionCode":"alwaysChallenge",
+          "idempotencyKey":"aaafac77-42c9-486f-9a6e-086b63f32a5c",
+          "verificationMethod":"AUTHENTICATOR_APP"
+        }.to_json, 
+        headers: {'Content-Type' => 'application/json'}
+      )
+
       response = Authsignal.validate_challenge(
         user_id: "legitimate_user_id",
-        token: token,
+        token: "token",
       )
 
       expect(response[:user_id]).to eq("legitimate_user_id")
@@ -146,9 +137,20 @@ RSpec.describe Authsignal do
     end
 
     it "Checks that success is false when userId is incorrect" do
+      stub_request(:post, "http://localhost:8080/validate")
+      .with(
+        headers: {
+          'Content-Type'=>'application/json',
+        })
+      .to_return(
+        status: 200, 
+        body: {"error":"invalid_request","errorDescription":"The user is invalid."}.to_json, 
+        headers: {'Content-Type' => 'application/json'}
+      )
+
       response = Authsignal.validate_challenge(
         user_id: "spoofed_user_id",
-        token: token,
+        token: "token",
       )
 
       expect(response[:state]).to eq(nil)


### PR DESCRIPTION
This PR simplifies the validate_challenge method by calling Authsignal's API to validate a challenge. It now returns `is_valid` instead of `success` which causes a breaking change. 