### PR TITLE
Add update_action_state method 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    authsignal-ruby (4.0.0)
+    authsignal-ruby (4.1.0)
       faraday (>= 2)
       faraday-retry (~> 2.2)
 

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -49,6 +49,13 @@ module Authsignal
             handle_response(response)
         end
 
+        def update_action_state(user_id:, action:, idempotency_key:, state:)
+            # NOTE: Rely on API to respond when given invalid state
+            response = Client.new.update_action_state(user_id: user_id, action: action, idempotency_key: idempotency_key, state: state)
+
+            handle_response(response)
+        end
+
         def enroll_verified_authenticator(user_id:, authenticator:)
             response = Client.new.enroll_verified_authenticator(user_id, authenticator)
 

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -74,6 +74,11 @@ module Authsignal
             make_request(:get, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}")
         end
 
+        def update_action_state(user_id:, action:, idempotency_key:, state:) 
+            body = { state: state }
+            make_request(:patch, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}", body: body)
+        end
+
         ##
         # TODO: delete identify?
         def identify(user_id, user_payload)

--- a/lib/authsignal/version.rb
+++ b/lib/authsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Authsignal
-  VERSION = "4.0.0"
+  VERSION = "4.1.0"
 end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -221,6 +221,34 @@ RSpec.describe Authsignal do
     end
   end
 
+  describe ".update_action_state" do
+    let(:user_id) { "100" }
+    let(:action) { "testAction" }
+    let(:idempotency_key) { "15cac140-f639-48c5-92db-835ec8d3d144" }
+    let(:state) { "ALLOW" }
+
+    it "succeeds" do
+      stub_request(:patch, "#{base_uri}/users/#{user_id}/actions/#{action}/#{idempotency_key}")
+          .with(
+            basic_auth: ['secret', ''],
+            headers: { 'Content-Type'=>'application/json' })
+          .to_return(body: {state: state, ruleIds: [], stateUpdatedAt: "2024-11-01T03:19:00.316Z", createdAt: "2024-11-01T03:19:00.316Z"}.to_json,
+            status: 200,
+            headers: {'Content-Type' => 'application/json'})
+
+      response = described_class.update_action_state(
+        user_id: user_id,
+        action: action, 
+        idempotency_key: idempotency_key,
+        state: state
+      ) 
+
+      expect(response[:state]).to eq(state)
+      expect(response[:state_updated_at]).to eq("2024-11-01T03:19:00.316Z")
+      expect(response[:success?]).to be true      
+    end
+  end
+
   describe ".validate_challenge" do
     it "Checks that the isValid is true when userId correct" do
       stub_request(:post, "#{base_uri}/validate")


### PR DESCRIPTION
Hi Authsignal 👋 

I'm looking to add the functionality to update action states in the SDK. 

Currently, our application uses an HTTP client directly. If possible, would like to move to the SDK. I have prepared a PR to facilitate this move. 

### Testing
In addition to writing a spec. I have also tested this functionality via `bin/console` and it works as expected.
```ruby
### testing methodology

# registered user
user_id = "neebs_user" 
action = "build_house"

# Creating a new action
response = Authsignal.track({user_id: user_id, action: action})
response[:state] # expected - "CHALLENGE_REQUIRED"

idempotency_key = response[:idempotency_key]

# Updating action status 
new_state = "ALLOW"
response = Authsignal.update_action_state(user_id: user_id, action: action, idempotency_key: idempotency_key, state: new_state)
response[:state] # expected - "ALLOW" 

# Confirmation of updated action status
response = Authsignal.get_action(user_id: user_id, action: action, idempotency_key: idempotency_key) 
response[:state] #  expected - "ALLOW" 
```

---


Let me know if there are issues with this change. 

Cheers!