### PR TITLE
Update error handling to new conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can find your `api_secret_key` in the [Authsignal Portal](https://portal.aut
 
 You must specify the correct `api_url` for your tenant's region.
 
-| Region      | Base URL                            |
+| Region      | API URL                             |
 | ----------- | ----------------------------------- |
 | US (Oregon) | https://signal.authsignal.com/v1    |
 | AU (Sydney) | https://au.signal.authsignal.com/v1 |

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Authsignal.enroll_verified_authenticator user_id: 'AS_001',
 # returns:
 # {
 #    success?: false,
-#    status: 400,
-#    error: 'invalid_request',
+#    status_code: 400,
+#    error_code: 'invalid_request',
 #    error_description: '/body/oobChannel must be equal to one of the allowed values'
 # }
 ```
@@ -109,7 +109,7 @@ Authsignal.enroll_verified_authenticator! user_id: 'AS_001',
                                          }
 
 # raise:
-# <Authsignal::ApiError: invalid_request status: 400, error: invalid_request, description: /body/oobChannel must be equal to one o...
+# <Authsignal::ApiError: AuthsignalError: 400 - /body/oobChannel must be equal to one of the allowed values. status_code: 401, error_code: invalid_request, error_description: /body/oobChannel must be equal to one of the allowed values.
 ```
 
 ## Development

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -99,9 +99,9 @@ module Authsignal
         def handle_error_response(response)
             case response.body
             when Hash
-                response.body.merge(status: response.status, success?: false)
+                { status_code: response.status, success?: false, error_code: response.body[:error], error_description: response.body[:error_description] }
             else
-                { status: response&.status || 500, success?: false }
+                { status_code: response&.status || 500, success?: false }
             end
         end
     end
@@ -110,11 +110,11 @@ module Authsignal
     (methods - NON_API_METHODS).each do |method|
         define_singleton_method("#{method}!") do |*args, **kwargs|
             send(method, *args, **kwargs).tap do |response|
-                status = response[:status]
-                err = response[:error]
-                desc = response[:error_description]
+                status_code = response[:status_code]
+                error_code = response[:error_code]
+                error_description = response[:error_description]
 
-                raise ApiError.new(err, status, err, desc) unless response[:success?]
+                raise ApiError.new(status_code, error_code, error_description) unless response[:success?]
             end
         end
     end

--- a/lib/authsignal/api_error.rb
+++ b/lib/authsignal/api_error.rb
@@ -2,18 +2,30 @@
 
 module Authsignal
   class ApiError < StandardError
-    attr_reader :status, :error, :description
+    attr_reader :status_code, :error_code, :error_description
 
-    def initialize(message = "An unexpected API error occurred", status, error, description)
-      @status      = status || 500
-      @error       = error
-      @description = description
+    def initialize(status_code, error_code, error_description = nil)
+      message = format_message(status_code, error_code, error_description)
 
       super(message)
+
+      @status_code = status_code
+      @error_code = error_code
+      @error_description = error_description
     end
 
     def to_s
-      "#{super} status: #{status}, error: #{error}, description: #{description}"
+      "#{super} status_code: #{status_code}, error_code: #{error_code}, error_description: #{error_description}"
+    end
+
+    private
+
+    def format_message(status_code, error_code, error_description)
+      "AuthsignalError: #{status_code} - #{format_description(error_code, error_description)}"
+    end
+
+    def format_description(error_code, error_description)
+      error_description && error_description.length > 0 ? error_description : error_code
     end
   end
 end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe Authsignal do
         })
       .to_return(
         status: 404, 
-        body: {"error":"unauthorized", "errorDescription":"The request is unauthorized. Check that your API key and region base URL are correctly configured."}.to_json, 
+        body: {"error":"unauthorized", "errorDescription":"The request is unauthorized. Check that your API key and region api URL are correctly configured."}.to_json, 
         headers: {'Content-Type' => 'application/json'}
       )
 
@@ -352,7 +352,7 @@ RSpec.describe Authsignal do
         token:   "token",
       )
 
-      expect(response).to eq error_code: "unauthorized", status_code: 404, error_description: "The request is unauthorized. Check that your API key and region base URL are correctly configured.", success?: false
+      expect(response).to eq error_code: "unauthorized", status_code: 404, error_description: "The request is unauthorized. Check that your API key and region api URL are correctly configured.", success?: false
     end
   end
 end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Authsignal do
                    body: { error: "unauthorized", errorDescription: "Session expired" }.to_json )
 
       response = described_class.track(action: "signIn", idempotency_key: idempotency_key, user_id: "123")
-      expect(response).to eq status: 401, error: "unauthorized", error_description: "Session expired", success?: false
+      expect(response).to eq status_code: 401, error_code: "unauthorized", error_description: "Session expired", success?: false
     end
   end
 
@@ -187,7 +187,7 @@ RSpec.describe Authsignal do
         .to_return(status: 400)
 
       response = described_class.track(action: "signIn", idempotency_key: idempotency_key, user_id: "123")
-      expect(response).to eq status: 400, success?: false
+      expect(response).to eq status_code: 400, success?: false
     end
 
     it 'handles errors' do
@@ -196,7 +196,7 @@ RSpec.describe Authsignal do
         .to_return_json(status: 401, body: { error: "unauthorized", errorDescription: "Session expired" } )
 
       response = described_class.track(action: "signIn", idempotency_key: idempotency_key, user_id: "123")
-      expect(response).to eq status: 401, error: "unauthorized", error_description: "Session expired", success?: false
+      expect(response).to eq status_code: 401, error_code: "unauthorized", error_description: "Session expired", success?: false
     end
 
   end
@@ -343,7 +343,7 @@ RSpec.describe Authsignal do
         })
       .to_return(
         status: 404, 
-        body: {"message":"Not Found"}.to_json, 
+        body: {"error":"unauthorized", "errorDescription":"The request is unauthorized. Check that your API key and region base URL are correctly configured."}.to_json, 
         headers: {'Content-Type' => 'application/json'}
       )
 
@@ -352,7 +352,7 @@ RSpec.describe Authsignal do
         token:   "token",
       )
 
-      expect(response).to eq status: 404, message: "Not Found", success?: false
+      expect(response).to eq error_code: "unauthorized", status_code: 404, error_description: "The request is unauthorized. Check that your API key and region base URL are correctly configured.", success?: false
     end
   end
 end


### PR DESCRIPTION
Error handling changes:

Error response `status` replaced with `status_code`
`error` replaced with `error_code`