### PR TITLE
Update function signatures to new convention

### DIFF
--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -56,8 +56,8 @@ module Authsignal
             handle_response(response)
         end
 
-        def enroll_verified_authenticator(user_id:, authenticator:)
-            response = Client.new.enroll_verified_authenticator(user_id, authenticator)
+        def enroll_verified_authenticator(user_id:, attributes:)
+            response = Client.new.enroll_verified_authenticator(user_id: user_id, attributes: attributes)
 
             handle_response(response)
         end

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -44,7 +44,7 @@ module Authsignal
         end
 
         def get_action(user_id:, action:, idempotency_key:)
-            response = Client.new.get_action(user_id, action, idempotency_key)
+            response = Client.new.get_action(user_id: user_id, action: action, idempotency_key: idempotency_key)
 
             handle_response(response)
         end

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -25,8 +25,8 @@ module Authsignal
             configuration.defaults
         end
 
-        def get_user(user_id:, redirect_url: nil)
-            response = Client.new.get_user(user_id: user_id, redirect_url: redirect_url)
+        def get_user(user_id:)
+            response = Client.new.get_user(user_id: user_id)
 
             handle_response(response)
         end
@@ -62,7 +62,7 @@ module Authsignal
             handle_response(response)
         end
 
-        def delete_authenticator(user_id:, user_authenticator_id: )
+        def delete_authenticator(user_id:, user_authenticator_id:)
             response = Client.new.delete_authenticator(user_id: user_id, user_authenticator_id: user_authenticator_id)
 
             handle_response(response)

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -74,7 +74,7 @@ module Authsignal
         end
 
         def validate_challenge(token:, user_id: nil, action: nil)
-            response = Client.new.validate_challenge(user_id: user_id, token: token, action: action)
+            response = Client.new.validate_challenge(token: token,user_id: user_id, action: action)
             
             handle_response(response)
         end

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -68,11 +68,8 @@ module Authsignal
             handle_response(response)
         end
 
-        def track(event, options={})
-            raise ArgumentError, "Action Code is required" unless event[:action].to_s.length > 0
-            raise ArgumentError, "User ID value" unless event[:user_id].to_s.length > 0
-
-            response = Client.new.track(event)
+        def track(:user_id, :action, :attributes)
+            response = Client.new.track(user_id, action, attributes)
             handle_response(response)
         end
 

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -69,7 +69,7 @@ module Authsignal
         end
 
         def track(:user_id, :action, :attributes)
-            response = Client.new.track(user_id, action, attributes)
+            response = Client.new.track(user_id: user_id, action: action, attributes: attributes)
             handle_response(response)
         end
 

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -43,6 +43,12 @@ module Authsignal
             handle_response(response)
         end
 
+        def get_authenticators(user_id:)
+            response = Client.new.get_authenticators(user_id: user_id)
+
+            handle_response(response)
+        end
+
         def enroll_verified_authenticator(user_id:, attributes:)
             response = Client.new.enroll_verified_authenticator(user_id: user_id, attributes: attributes)
 
@@ -90,7 +96,11 @@ module Authsignal
         end
 
         def handle_success_response(response)
-            response.body.merge(success?: true)
+            if response.body.is_a?(Array)
+                { success?: true, data: response.body }
+            else
+                response.body.merge(success?: true)
+            end
         end
 
         def handle_error_response(response)

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -49,9 +49,9 @@ module Authsignal
             handle_response(response)
         end
 
-        def update_action_state(user_id:, action:, idempotency_key:, attributes:)
+        def update_action(user_id:, action:, idempotency_key:, attributes:)
             # NOTE: Rely on API to respond when given invalid state
-            response = Client.new.update_action_state(user_id: user_id, action: action, idempotency_key: idempotency_key, attributes: attributes)
+            response = Client.new.update_action(user_id: user_id, action: action, idempotency_key: idempotency_key, attributes: attributes)
 
             handle_response(response)
         end

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -79,7 +79,6 @@ module Authsignal
         end
 
         def update_action(user_id:, action:, idempotency_key:, attributes:)
-            # NOTE: Rely on API to respond when given invalid state
             response = Client.new.update_action(user_id: user_id, action: action, idempotency_key: idempotency_key, attributes: attributes)
 
             handle_response(response)

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -43,19 +43,6 @@ module Authsignal
             handle_response(response)
         end
 
-        def get_action(user_id:, action:, idempotency_key:)
-            response = Client.new.get_action(user_id: user_id, action: action, idempotency_key: idempotency_key)
-
-            handle_response(response)
-        end
-
-        def update_action(user_id:, action:, idempotency_key:, attributes:)
-            # NOTE: Rely on API to respond when given invalid state
-            response = Client.new.update_action(user_id: user_id, action: action, idempotency_key: idempotency_key, attributes: attributes)
-
-            handle_response(response)
-        end
-
         def enroll_verified_authenticator(user_id:, attributes:)
             response = Client.new.enroll_verified_authenticator(user_id: user_id, attributes: attributes)
 
@@ -76,6 +63,19 @@ module Authsignal
         def validate_challenge(token:, user_id: nil, action: nil)
             response = Client.new.validate_challenge(token: token,user_id: user_id, action: action)
             
+            handle_response(response)
+        end
+
+        def get_action(user_id:, action:, idempotency_key:)
+            response = Client.new.get_action(user_id: user_id, action: action, idempotency_key: idempotency_key)
+
+            handle_response(response)
+        end
+
+        def update_action(user_id:, action:, idempotency_key:, attributes:)
+            # NOTE: Rely on API to respond when given invalid state
+            response = Client.new.update_action(user_id: user_id, action: action, idempotency_key: idempotency_key, attributes: attributes)
+
             handle_response(response)
         end
 

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -68,7 +68,7 @@ module Authsignal
             handle_response(response)
         end
 
-        def track(:user_id, :action, :attributes)
+        def track(user_id:, action:, attributes:)
             response = Client.new.track(user_id: user_id, action: action, attributes: attributes)
             handle_response(response)
         end

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -31,8 +31,8 @@ module Authsignal
             handle_response(response)
         end
 
-        def update_user(user_id:, user:)
-            response = Client.new.update_user(user_id: user_id, user: user)
+        def update_user(user_id:, attributes:)
+            response = Client.new.update_user(user_id: user_id, attributes: attributes)
 
             handle_response(response)
         end

--- a/lib/authsignal.rb
+++ b/lib/authsignal.rb
@@ -49,9 +49,9 @@ module Authsignal
             handle_response(response)
         end
 
-        def update_action_state(user_id:, action:, idempotency_key:, state:)
+        def update_action_state(user_id:, action:, idempotency_key:, attributes:)
             # NOTE: Rely on API to respond when given invalid state
-            response = Client.new.update_action_state(user_id: user_id, action: action, idempotency_key: idempotency_key, state: state)
+            response = Client.new.update_action_state(user_id: user_id, action: action, idempotency_key: idempotency_key, attributes: attributes)
 
             handle_response(response)
         end

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -67,8 +67,7 @@ module Authsignal
         end
 
         def update_action(user_id:, action:, idempotency_key:, attributes:) 
-            body = { state: attributes.state }
-            make_request(:patch, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}", body: body)
+            make_request(:patch, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}", body: attributes)
         end
 
         ##

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -36,12 +36,6 @@ module Authsignal
             end
         end
 
-        def track(user_id:, action:, attributes:)
-            path = "users/#{user_id}/actions/#{action}"
-
-            make_request(:post, path, body: attributes)
-        end
-
         def get_user(user_id:)
             path = "users/#{url_encode(user_id)}"
             make_request(:get, path)
@@ -53,6 +47,20 @@ module Authsignal
 
         def delete_user(user_id:)
             make_request(:delete, "users/#{url_encode(user_id)}")
+        end
+
+        def enroll_verified_authenticator(user_id:, attributes:)
+            make_request(:post, "users/#{url_encode(user_id)}/authenticators", body: attributes)
+        end
+
+        def delete_authenticator(user_id:, user_authenticator_id:)
+            make_request(:delete, "users/#{url_encode(user_id)}/authenticators/#{url_encode(user_authenticator_id)}")
+        end
+
+        def track(user_id:, action:, attributes:)
+            path = "users/#{user_id}/actions/#{action}"
+
+            make_request(:post, path, body: attributes)
         end
 
         def validate_challenge(token:, user_id: nil, action: nil)
@@ -74,14 +82,6 @@ module Authsignal
         # TODO: delete identify?
         def identify(user_id, user_payload)
             make_request(:post , "users/#{url_encode(user_id)}", body: user_payload)
-        end
-
-        def enroll_verified_authenticator(user_id:, attributes:)
-            make_request(:post, "users/#{url_encode(user_id)}/authenticators", body: attributes)
-        end
-
-        def delete_authenticator(user_id:, user_authenticator_id:)
-            make_request(:delete, "users/#{url_encode(user_id)}/authenticators/#{url_encode(user_authenticator_id)}")
         end
 
         private

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -66,8 +66,8 @@ module Authsignal
             make_request(:get, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}")
         end
 
-        def update_action_state(user_id:, action:, idempotency_key:, state:) 
-            body = { state: state }
+        def update_action_state(user_id:, action:, idempotency_key:, attributes:) 
+            body = { state: attributes.state }
             make_request(:patch, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}", body: body)
         end
 

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -66,7 +66,7 @@ module Authsignal
             make_request(:get, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}")
         end
 
-        def update_action_state(user_id:, action:, idempotency_key:, attributes:) 
+        def update_action(user_id:, action:, idempotency_key:, attributes:) 
             body = { state: attributes.state }
             make_request(:patch, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}", body: body)
         end

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -42,12 +42,8 @@ module Authsignal
             make_request(:post, path, body: attributes)
         end
 
-        def get_user(user_id:, redirect_url: nil)
-            if(redirect_url)
-                path = "users/#{url_encode(user_id)}?redirectUrl=#{redirect_url}"
-            else
-                path = "users/#{url_encode(user_id)}"
-            end
+        def get_user(user_id:)
+            path = "users/#{url_encode(user_id)}"
             make_request(:get, path)
         end
 

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -55,8 +55,8 @@ module Authsignal
             make_request(:get, path)
         end
 
-        def update_user(user_id:, user:)
-            make_request(:post, "users/#{url_encode(user_id)}", body: user)
+        def update_user(user_id:, attributes:)
+            make_request(:post, "users/#{url_encode(user_id)}", body: attributes)
         end
 
         def delete_user(user_id:)

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -62,7 +62,7 @@ module Authsignal
             make_request(:post, path, body: body)
         end
 
-        def get_action(user_id, action, idempotency_key)
+        def get_action(user_id:, action:, idempotency_key:)
             make_request(:get, "users/#{url_encode(user_id)}/actions/#{action}/#{url_encode(idempotency_key)}")
         end
 

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -36,14 +36,10 @@ module Authsignal
             end
         end
 
-        def track(event)
-            user_id = url_encode(event[:user_id])
-            action = event[:action]
-
+        def track(:user_id, :action, :attributes)
             path = "users/#{user_id}/actions/#{action}"
-            body = event.except(:user_id)
 
-            make_request(:post, path, body: body)
+            make_request(:post, path, body: attributes)
         end
 
         def get_user(user_id:, redirect_url: nil)

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -63,7 +63,7 @@ module Authsignal
             make_request(:delete, "users/#{url_encode(user_id)}")
         end
 
-        def validate_challenge(user_id: nil, token:, action: nil)
+        def validate_challenge(token:, user_id: nil, action: nil)
             path = "validate"
             body = { user_id: user_id, token: token, action: action }
 

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -49,6 +49,10 @@ module Authsignal
             make_request(:delete, "users/#{url_encode(user_id)}")
         end
 
+        def get_authenticators(user_id:)
+            make_request(:get, "users/#{url_encode(user_id)}/authenticators")
+        end
+
         def enroll_verified_authenticator(user_id:, attributes:)
             make_request(:post, "users/#{url_encode(user_id)}/authenticators", body: attributes)
         end

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -81,8 +81,8 @@ module Authsignal
             make_request(:post , "users/#{url_encode(user_id)}", body: user_payload)
         end
 
-        def enroll_verified_authenticator(user_id, authenticator)
-            make_request(:post, "users/#{url_encode(user_id)}/authenticators", body: authenticator)
+        def enroll_verified_authenticator(user_id:, attributes:)
+            make_request(:post, "users/#{url_encode(user_id)}/authenticators", body: attributes)
         end
 
         def delete_authenticator(user_id:, user_authenticator_id:)

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -36,7 +36,7 @@ module Authsignal
             end
         end
 
-        def track(:user_id, :action, :attributes)
+        def track(user_id:, action:, attributes:)
             path = "users/#{user_id}/actions/#{action}"
 
             make_request(:post, path, body: attributes)

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -79,6 +79,39 @@ RSpec.describe Authsignal do
     end
   end
 
+  describe ".get_authenticators" do
+    let(:user_id) { "100" }
+    
+    let(:authenticator) {{
+        userAuthenticatorId: "18fbbe25-f84d-49ab-ab71-577adaefee25",
+        authenticatorType: "OOB", 
+        verificationMethod: "EMAIL_MAGIC_LINK",
+        createdAt: "2024-10-09T02:58:33.911Z",
+        email: "email@authsignal.com",
+        oobChannel: "EMAIL_MAGIC_LINK",
+        verifiedAt: "2024-10-09T02:59:19.995Z",
+        lastVerifiedAt: "2024-10-09T02:59:19.995Z"     
+    }}
+
+
+    it "succeeds" do
+      stub_request(:get, "#{api_url}/users/#{user_id}/authenticators")
+          .with(
+            basic_auth: ['secret', ''],
+            headers: { 'Content-Type'=>'application/json' })
+          .to_return(body: [authenticator].to_json,
+            status: 200,
+            headers: {'Content-Type' => 'application/json'})
+
+      response = described_class.get_authenticators(
+        user_id: user_id,
+      ) 
+
+      expect(response[:data]).to eq([authenticator])
+      expect(response[:success?]).to be true      
+    end
+  end
+
   describe ".enroll_verified_authenticator" do
     it 'succeeds' do
       payload = {
@@ -198,54 +231,6 @@ RSpec.describe Authsignal do
 
   end
 
-  describe ".get_action" do
-    it 'succeeds' do
-      stub_request(:get, "#{api_url}/users/1/actions/testAction/15cac140-f639-48c5-92db-835ec8d3d144")
-          .with(basic_auth: ['secret', ''])
-          .to_return(body: {state: "ALLOW", ruleIds: [], stateUpdatedAt: "2022-07-25T03:19:00.316Z", createdAt: "2022-07-25T03:19:00.316Z"}.to_json,
-                    status: 200,
-                    headers: {'Content-Type' => 'application/json'})
-        
-      response = described_class.get_action(
-        user_id: 1,
-        action: "testAction",
-        idempotency_key: "15cac140-f639-48c5-92db-835ec8d3d144")
-    
-
-      expect(response[:state]).to eq("ALLOW")
-      expect(response[:state_updated_at]).to eq("2022-07-25T03:19:00.316Z")
-      expect(response[:success?]).to be true
-    end
-  end
-
-  describe ".update_action" do
-    let(:user_id) { "100" }
-    let(:action) { "testAction" }
-    let(:idempotency_key) { "15cac140-f639-48c5-92db-835ec8d3d144" }
-    let(:state) { "ALLOW" }
-
-    it "succeeds" do
-      stub_request(:patch, "#{api_url}/users/#{user_id}/actions/#{action}/#{idempotency_key}")
-          .with(
-            basic_auth: ['secret', ''],
-            headers: { 'Content-Type'=>'application/json' })
-          .to_return(body: {state: state, ruleIds: [], stateUpdatedAt: "2024-11-01T03:19:00.316Z", createdAt: "2024-11-01T03:19:00.316Z"}.to_json,
-            status: 200,
-            headers: {'Content-Type' => 'application/json'})
-
-      response = described_class.update_action(
-        user_id: user_id,
-        action: action, 
-        idempotency_key: idempotency_key,
-        attributes: { state: state }
-      ) 
-
-      expect(response[:state]).to eq(state)
-      expect(response[:state_updated_at]).to eq("2024-11-01T03:19:00.316Z")
-      expect(response[:success?]).to be true      
-    end
-  end
-
   describe ".validate_challenge" do
     it "Checks that the isValid is true when userId correct" do
       stub_request(:post, "#{api_url}/validate")
@@ -351,38 +336,52 @@ RSpec.describe Authsignal do
 
       expect(response).to eq error_code: "unauthorized", status_code: 404, error_description: "The request is unauthorized. Check that your API key and region api URL are correctly configured.", success?: false
     end
-    
   end
 
-  describe ".get_authenticators" do
-    let(:user_id) { "100" }
+  describe ".get_action" do
+    it 'succeeds' do
+      stub_request(:get, "#{api_url}/users/1/actions/testAction/15cac140-f639-48c5-92db-835ec8d3d144")
+          .with(basic_auth: ['secret', ''])
+          .to_return(body: {state: "ALLOW", ruleIds: [], stateUpdatedAt: "2022-07-25T03:19:00.316Z", createdAt: "2022-07-25T03:19:00.316Z"}.to_json,
+                    status: 200,
+                    headers: {'Content-Type' => 'application/json'})
+        
+      response = described_class.get_action(
+        user_id: 1,
+        action: "testAction",
+        idempotency_key: "15cac140-f639-48c5-92db-835ec8d3d144")
     
-    let(:authenticator) {{
-        userAuthenticatorId: "18fbbe25-f84d-49ab-ab71-577adaefee25",
-        authenticatorType: "OOB", 
-        verificationMethod: "EMAIL_MAGIC_LINK",
-        createdAt: "2024-10-09T02:58:33.911Z",
-        email: "email@authsignal.com",
-        oobChannel: "EMAIL_MAGIC_LINK",
-        verifiedAt: "2024-10-09T02:59:19.995Z",
-        lastVerifiedAt: "2024-10-09T02:59:19.995Z"     
-    }}
 
+      expect(response[:state]).to eq("ALLOW")
+      expect(response[:state_updated_at]).to eq("2022-07-25T03:19:00.316Z")
+      expect(response[:success?]).to be true
+    end
+  end
+
+  describe ".update_action" do
+    let(:user_id) { "100" }
+    let(:action) { "testAction" }
+    let(:idempotency_key) { "15cac140-f639-48c5-92db-835ec8d3d144" }
+    let(:state) { "ALLOW" }
 
     it "succeeds" do
-      stub_request(:get, "#{api_url}/users/#{user_id}/authenticators")
+      stub_request(:patch, "#{api_url}/users/#{user_id}/actions/#{action}/#{idempotency_key}")
           .with(
             basic_auth: ['secret', ''],
             headers: { 'Content-Type'=>'application/json' })
-          .to_return(body: [authenticator].to_json,
+          .to_return(body: {state: state, ruleIds: [], stateUpdatedAt: "2024-11-01T03:19:00.316Z", createdAt: "2024-11-01T03:19:00.316Z"}.to_json,
             status: 200,
             headers: {'Content-Type' => 'application/json'})
 
-      response = described_class.get_authenticators(
+      response = described_class.update_action(
         user_id: user_id,
+        action: action, 
+        idempotency_key: idempotency_key,
+        attributes: { state: state }
       ) 
 
-      expect(response[:data]).to eq([authenticator])
+      expect(response[:state]).to eq(state)
+      expect(response[:state_updated_at]).to eq("2024-11-01T03:19:00.316Z")
       expect(response[:success?]).to be true      
     end
   end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -351,5 +351,39 @@ RSpec.describe Authsignal do
 
       expect(response).to eq error_code: "unauthorized", status_code: 404, error_description: "The request is unauthorized. Check that your API key and region api URL are correctly configured.", success?: false
     end
+    
+  end
+
+  describe ".get_authenticators" do
+    let(:user_id) { "100" }
+    
+    let(:authenticator) {{
+        userAuthenticatorId: "18fbbe25-f84d-49ab-ab71-577adaefee25",
+        authenticatorType: "OOB", 
+        verificationMethod: "EMAIL_MAGIC_LINK",
+        createdAt: "2024-10-09T02:58:33.911Z",
+        email: "email@authsignal.com",
+        oobChannel: "EMAIL_MAGIC_LINK",
+        verifiedAt: "2024-10-09T02:59:19.995Z",
+        lastVerifiedAt: "2024-10-09T02:59:19.995Z"     
+    }}
+
+
+    it "succeeds" do
+      stub_request(:get, "#{api_url}/users/#{user_id}/authenticators")
+          .with(
+            basic_auth: ['secret', ''],
+            headers: { 'Content-Type'=>'application/json' })
+          .to_return(body: [authenticator].to_json,
+            status: 200,
+            headers: {'Content-Type' => 'application/json'})
+
+      response = described_class.get_authenticators(
+        user_id: user_id,
+      ) 
+
+      expect(response[:data]).to eq([authenticator])
+      expect(response[:success?]).to be true      
+    end
   end
 end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Authsignal do
                    headers: { 'Content-Type' => 'text/plain' },
                    body: { error: "unauthorized", errorDescription: "Session expired" }.to_json )
 
-      response = described_class.track(action: "signIn", idempotency_key: idempotency_key, user_id: "123")
+      response = described_class.track(user_id: "123", action: "signIn", attributes: { idempotency_key: idempotency_key })
       expect(response).to eq status_code: 401, error_code: "unauthorized", error_description: "Session expired", success?: false
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe Authsignal do
                     status: 200,
                     headers: {'Content-Type' => 'application/json'})
 
-      response = described_class.update_user(user_id: 1, user: { email: "test@test.com" })
+      response = described_class.update_user(user_id: 1, attributes: { email: "test@test.com" })
 
       expect(response[:email]).to eq("test@test.com")
       expect(response[:success?]).to be true
@@ -101,7 +101,7 @@ RSpec.describe Authsignal do
                     headers: {'Content-Type' => 'application/json'})
         
       response = described_class.enroll_verified_authenticator(user_id: 1,
-                    authenticator:{ oob_channel: "SMS",
+                    attributes:{ oob_channel: "SMS",
                       phone_number: "+64270000000" })
 
       expect(response).to eq({
@@ -145,7 +145,6 @@ RSpec.describe Authsignal do
         .with(basic_auth: ['secret', ''],
               body: {
                 idempotencyKey: idempotency_key,
-                action: action,
                 redirectUrl: "https://wwww.example.com",
                 email: "test@example.com",
                 deviceId: "xxx",
@@ -162,11 +161,9 @@ RSpec.describe Authsignal do
               })
         .to_return_json(body: { state: "ALLOW", idempotencyKey: idempotency_key, ruleIds: [] })
 
-      response = described_class.track({
-                                    action: action,
+      response = described_class.track(user_id: user_id, action: action, attributes: {
                                     idempotency_key: idempotency_key,
                                     redirect_url: "https://wwww.example.com",
-                                    user_id: user_id,
                                     email: "test@example.com",
                                     device_id: "xxx",
                                     user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:102.0) Gecko/20100101 Firefox/102.0",
@@ -186,7 +183,7 @@ RSpec.describe Authsignal do
         .with(basic_auth: ['secret', ''])
         .to_return(status: 400)
 
-      response = described_class.track(action: "signIn", idempotency_key: idempotency_key, user_id: "123")
+      response = described_class.track(action: "signIn", user_id: "123", attributes: { idempotency_key: idempotency_key })
       expect(response).to eq status_code: 400, success?: false
     end
 
@@ -195,7 +192,7 @@ RSpec.describe Authsignal do
         .with(basic_auth: ['secret', ''])
         .to_return_json(status: 401, body: { error: "unauthorized", errorDescription: "Session expired" } )
 
-      response = described_class.track(action: "signIn", idempotency_key: idempotency_key, user_id: "123")
+      response = described_class.track(action: "signIn", user_id: "123", attributes: { idempotency_key: idempotency_key })
       expect(response).to eq status_code: 401, error_code: "unauthorized", error_description: "Session expired", success?: false
     end
 
@@ -221,7 +218,7 @@ RSpec.describe Authsignal do
     end
   end
 
-  describe ".update_action_state" do
+  describe ".update_action" do
     let(:user_id) { "100" }
     let(:action) { "testAction" }
     let(:idempotency_key) { "15cac140-f639-48c5-92db-835ec8d3d144" }
@@ -236,11 +233,11 @@ RSpec.describe Authsignal do
             status: 200,
             headers: {'Content-Type' => 'application/json'})
 
-      response = described_class.update_action_state(
+      response = described_class.update_action(
         user_id: user_id,
         action: action, 
         idempotency_key: idempotency_key,
-        state: state
+        attributes: { state: state }
       ) 
 
       expect(response[:state]).to eq(state)

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -84,11 +84,9 @@ RSpec.describe Authsignal do
     
     let(:authenticator) {{
         userAuthenticatorId: "18fbbe25-f84d-49ab-ab71-577adaefee25",
-        authenticatorType: "OOB", 
         verificationMethod: "EMAIL_MAGIC_LINK",
         createdAt: "2024-10-09T02:58:33.911Z",
         email: "email@authsignal.com",
-        oobChannel: "EMAIL_MAGIC_LINK",
         verifiedAt: "2024-10-09T02:59:19.995Z",
         lastVerifiedAt: "2024-10-09T02:59:19.995Z"     
     }}


### PR DESCRIPTION
### Breaking Changes

1. **`validate_challenge`**
   - **Old:** `validate_challenge(user_id: nil, token:, action: nil)`
   - **New:** `validate_challenge(token:, user_id: nil, action: nil)`

2. **`update_user`**
   - Renamed the `user` parameter to `attributes` in the `update_user` function.

3. **`track`**
   - Updated function signature:
     - **Old:** `def track(event)`
     - **New:** `def track(:user_id, :action, :attributes)`

4. **`enroll_verified_authenticator`**
   - Updated to accept named parameters: `user_id` and `attributes`.

5. **`get_user`**
   - Removed `redirectUrl` from the function signature.

6. **`update_action_state`**
   - Renamed `update_action_state` to `update_action`.
   - Renamed input parameter `state` to `attributes`.

### Non-Breaking Changes
1. **`get_authenticators`**
   - Added `get_authenticators` method.
