### PR TITLE
Set faraday version to >2.0.1 which includes the transitive dependency faraday-net_http

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    authsignal-ruby (5.0.0)
-      faraday (>= 2)
+    authsignal-ruby (5.0.1)
+      faraday (>= 2.0.1)
       faraday-retry (~> 2.2)
 
 GEM
@@ -61,4 +61,4 @@ DEPENDENCIES
   webmock (~> 3.14)
 
 BUNDLED WITH
-   2.5.16
+   2.5.14

--- a/authsignal-ruby.gemspec
+++ b/authsignal-ruby.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", ">= 2"
+  spec.add_dependency "faraday", ">= 2.0.1"
   spec.add_dependency "faraday-retry", "~> 2.2"
 
   spec.add_development_dependency "rspec", "~> 3.2"

--- a/lib/authsignal/version.rb
+++ b/lib/authsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Authsignal
-  VERSION = "5.0.0"
+  VERSION = "5.0.1"
 end


### PR DESCRIPTION
Fixes an issue where older versions of faraday results in the error:
```
#<Faraday::Error #<Faraday::Error: :net_http is not registered on Faraday::Adapter>>
```