### PR TITLE
Bump version for veriffSessionId support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    authsignal-ruby (5.4.0)
+    authsignal-ruby (5.5.0)
       base64
       faraday (>= 2.0.1)
       faraday-retry (~> 2.2)

--- a/lib/authsignal/version.rb
+++ b/lib/authsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Authsignal
-  VERSION = '5.4.0'
+  VERSION = '5.5.0'
 end

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -24,15 +24,13 @@ RSpec.describe Authsignal do
       user_id: user_id,
       attributes: {
         verification_method: 'SMS',
-        phone_number: '+6427000000'
+        phone_number: '+6427123456'
       }
     )
-    warn "DEBUG enroll_response: #{enroll_response.inspect}"
     expect(enroll_response).not_to be_nil
 
     # Get user
     user_response = described_class.get_user(user_id: user_id)
-    warn "DEBUG user_response: #{user_response.inspect}"
     expect(user_response).not_to be_nil
     expect(user_response[:is_enrolled]).to be true
     expect(user_response[:email]).to be_nil
@@ -78,7 +76,7 @@ RSpec.describe Authsignal do
       user_id: user_id,
       attributes: {
         verification_method: 'SMS',
-        phone_number: '+6427000000'
+        phone_number: '+6427123456'
       }
     )
     expect(enroll_response).not_to be_nil
@@ -112,7 +110,7 @@ RSpec.describe Authsignal do
       user_id: user_id,
       attributes: {
         verification_method: 'SMS',
-        phone_number: '+6427000000'
+        phone_number: '+6427123456'
       }
     )
     expect(enroll_response).not_to be_nil

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe Authsignal do
         phone_number: '+6427123456'
       }
     )
+    warn "DEBUG enroll_response: #{enroll_response.inspect}"
     expect(enroll_response).not_to be_nil
 
     # Get user
     user_response = described_class.get_user(user_id: user_id)
+    warn "DEBUG user_response: #{user_response.inspect}"
     expect(user_response).not_to be_nil
     expect(user_response[:is_enrolled]).to be true
     expect(user_response[:email]).to be_nil

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe Authsignal do
         phone_number: '+6427000000'
       }
     )
+    warn "DEBUG enroll_response: #{enroll_response.inspect}"
     expect(enroll_response).not_to be_nil
 
     # Get user
     user_response = described_class.get_user(user_id: user_id)
+    warn "DEBUG user_response: #{user_response.inspect}"
     expect(user_response).not_to be_nil
     expect(user_response[:is_enrolled]).to be true
     expect(user_response[:email]).to be_nil

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -27,12 +27,10 @@ RSpec.describe Authsignal do
         phone_number: '+64270000000'
       }
     )
-    warn "DEBUG enroll_response: #{enroll_response.inspect}"
     expect(enroll_response).not_to be_nil
 
     # Get user
     user_response = described_class.get_user(user_id: user_id)
-    warn "DEBUG user_response: #{user_response.inspect}"
     expect(user_response).not_to be_nil
     expect(user_response[:is_enrolled]).to be true
     expect(user_response[:email]).to be_nil

--- a/spec/authsignal/authsignal_spec.rb
+++ b/spec/authsignal/authsignal_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Authsignal do
       user_id: user_id,
       attributes: {
         verification_method: 'SMS',
-        phone_number: '+6427123456'
+        phone_number: '+64270000000'
       }
     )
     warn "DEBUG enroll_response: #{enroll_response.inspect}"
@@ -78,7 +78,7 @@ RSpec.describe Authsignal do
       user_id: user_id,
       attributes: {
         verification_method: 'SMS',
-        phone_number: '+6427123456'
+        phone_number: '+64270000000'
       }
     )
     expect(enroll_response).not_to be_nil
@@ -112,7 +112,7 @@ RSpec.describe Authsignal do
       user_id: user_id,
       attributes: {
         verification_method: 'SMS',
-        phone_number: '+6427123456'
+        phone_number: '+64270000000'
       }
     )
     expect(enroll_response).not_to be_nil


### PR DESCRIPTION
## Summary

- The validate-challenge response now includes `veriffSessionId` when the challenge was a Veriff session.
- Bumps version to `5.5.0`.