### PR TITLE
Enable retries by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    authsignal-ruby (5.5.0)
+    authsignal-ruby (5.6.0)
       base64
       faraday (>= 2.0.1)
       faraday-retry (~> 2.2)

--- a/README.md
+++ b/README.md
@@ -39,19 +39,6 @@ Authsignal.setup do |config|
 end
 ```
 
-### Retry policy
-
-Requests use a 3-second connect timeout, 10-second read timeout, and retry twice by default with exponential backoff and jitter. Transient network failures, `429`, and `5xx` responses are retried for `GET`, `HEAD`, and `OPTIONS`; writes are retried only when they carry an idempotency key.
-
-```ruby
-Authsignal.setup do |config|
-  config.retry = false # Disable retries
-  config.retries = 2
-  config.open_timeout = 3
-  config.timeout = 10
-end
-```
-
 ### API URLs by region
 
 | Region      | API URL                          |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ Authsignal.setup do |config|
 end
 ```
 
+### Retry policy
+
+Requests use a 3-second connect timeout, 10-second read timeout, and retry twice by default with exponential backoff and jitter. Transient network failures, `429`, and `5xx` responses are retried for `GET`, `HEAD`, and `OPTIONS`; writes are retried only when they carry an idempotency key.
+
+```ruby
+Authsignal.setup do |config|
+  config.retry = false # Disable retries
+  config.retries = 2
+  config.open_timeout = 3
+  config.timeout = 10
+end
+```
+
 ### API URLs by region
 
 | Region      | API URL                          |

--- a/lib/authsignal/client.rb
+++ b/lib/authsignal/client.rb
@@ -1,42 +1,35 @@
 # frozen_string_literal: true
 
 require 'erb'
+require 'json'
 
 module Authsignal
   class Client
     USER_AGENT = 'authsignal-ruby'
     NO_API_KEY_MESSAGE = 'No Authsignal API Secret Key Set'
 
+    SAFE_HTTP_METHODS = %i[get head options].freeze
+    RETRYABLE_STATUSES = ([429] + (500..599).to_a).freeze
     RETRY_OPTIONS = {
-      max: 3,
       interval: 0.1,
       interval_randomness: 0.5,
-      backoff_factor: 2
+      backoff_factor: 2,
+      methods: SAFE_HTTP_METHODS,
+      exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed],
+      retry_statuses: RETRYABLE_STATUSES,
+      retry_if: lambda do |env, _exception|
+        idempotency_key = env.request_headers['Idempotency-Key']
+        action_update = env.method == :patch && env.url.path.match?(%r{/actions/[^/]+/[^/]+$})
+
+        !idempotency_key.to_s.empty? || action_update
+      end
     }.freeze
     private_constant :RETRY_OPTIONS
 
-    def initialize(retry_options: RETRY_OPTIONS)
+    def initialize(retry_options: nil)
       @api_key = require_api_key
-
-      @client = Faraday.new do |builder|
-        builder.url_prefix = Authsignal.configuration.api_url
-        builder.adapter :net_http
-        builder.request :authorization, :basic, @api_key, nil
-
-        builder.headers['Accept'] = 'application/json'
-        builder.headers['Content-Type'] = 'application/json'
-        builder.headers['User-Agent'] = USER_AGENT
-        builder.headers['X-Authsignal-Version'] = Authsignal::VERSION
-
-        builder.request :json
-        builder.response :json, parser_options: { symbolize_names: true }
-
-        builder.use Middleware::JsonRequest
-        builder.use Middleware::JsonResponse
-
-        builder.request :retry, retry_options if Authsignal.configuration.retry
-        builder.response :logger, ::Logger.new($stdout), bodies: true if Authsignal.configuration.debug
-      end
+      retry_options ||= RETRY_OPTIONS.merge(max: Authsignal.configuration.retries)
+      @client = build_client(retry_options)
     end
 
     def get_user(user_id:)
@@ -237,6 +230,38 @@ module Authsignal
 
     private
 
+    def build_client(retry_options)
+      Faraday.new do |builder|
+        configure_transport(builder)
+        configure_headers(builder)
+        configure_middleware(builder, retry_options)
+      end
+    end
+
+    def configure_transport(builder)
+      builder.url_prefix = Authsignal.configuration.api_url
+      builder.adapter :net_http
+      builder.options.open_timeout = Authsignal.configuration.open_timeout
+      builder.options.timeout = Authsignal.configuration.timeout
+      builder.request :authorization, :basic, @api_key, nil
+    end
+
+    def configure_headers(builder)
+      builder.headers['Accept'] = 'application/json'
+      builder.headers['Content-Type'] = 'application/json'
+      builder.headers['User-Agent'] = USER_AGENT
+      builder.headers['X-Authsignal-Version'] = Authsignal::VERSION
+    end
+
+    def configure_middleware(builder, retry_options)
+      builder.request :json
+      builder.response :json, parser_options: { symbolize_names: true }
+      builder.use Middleware::JsonRequest
+      builder.use Middleware::JsonResponse
+      builder.request :retry, retry_options if Authsignal.configuration.retry
+      builder.response :logger, ::Logger.new($stdout), bodies: true if Authsignal.configuration.debug
+    end
+
     def url_encode(str)
       ERB::Util.url_encode(str)
     end
@@ -255,6 +280,8 @@ module Authsignal
 
     def make_request(method, path, body: nil, headers: nil)
       body = body.compact if body.is_a?(Hash)
+      idempotency_key = body.is_a?(Hash) && body[:idempotency_key]
+      headers = (headers || {}).merge('Idempotency-Key' => idempotency_key) if idempotency_key
       @client.public_send(method, path, body, headers)
     end
   end

--- a/lib/authsignal/configuration.rb
+++ b/lib/authsignal/configuration.rb
@@ -18,6 +18,9 @@ module Authsignal
     config_option :api_url
     config_option :debug
     config_option :retry
+    config_option :retries
+    config_option :open_timeout
+    config_option :timeout
 
     def initialize
       @config_values = {}
@@ -25,7 +28,10 @@ module Authsignal
       # set default attribute values
       @defaults = {
         api_url: 'https://signal.authsignal.com/v1/',
-        retry: false,
+        retry: true,
+        retries: 2,
+        open_timeout: 3,
+        timeout: 10,
         debug: false
       }
     end

--- a/lib/authsignal/version.rb
+++ b/lib/authsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Authsignal
-  VERSION = '5.5.0'
+  VERSION = '5.6.0'
 end

--- a/spec/authsignal/retry_spec.rb
+++ b/spec/authsignal/retry_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Authsignal::Client do
+  let(:api_url) { 'https://api.test.authsignal.com/v1/' }
+
+  before do
+    WebMock.disable_net_connect!
+    Authsignal.setup do |config|
+      config.api_secret_key = 'secret'
+      config.api_url = api_url
+      config.retry = true
+      config.retries = 2
+      config.open_timeout = 3
+      config.timeout = 10
+    end
+  end
+
+  after do
+    WebMock.allow_net_connect!
+  end
+
+  it 'uses consistent retry and timeout defaults' do
+    client = described_class.new
+    connection = client.instance_variable_get(:@client)
+
+    expect(Authsignal.configuration.retry).to be true
+    expect(Authsignal.configuration.retries).to eq(2)
+    expect(connection.options.open_timeout).to eq(3)
+    expect(connection.options.timeout).to eq(10)
+  end
+
+  it 'retries safe requests twice on 5xx' do
+    request = stub_request(:get, "#{api_url}users/user")
+              .to_return({ status: 503, body: '{}' }, { status: 503, body: '{}' }, { status: 200, body: '{}' })
+
+    described_class.new.get_user(user_id: 'user')
+
+    expect(request).to have_been_requested.times(3)
+  end
+
+  it 'retries 429 responses' do
+    request = stub_request(:get, "#{api_url}users/user")
+              .to_return({ status: 429, headers: { 'Retry-After' => '0' }, body: '{}' }, { status: 200, body: '{}' })
+
+    described_class.new.get_user(user_id: 'user')
+
+    expect(request).to have_been_requested.times(2)
+  end
+
+  it 'retries transient network failures' do
+    request = stub_request(:get, "#{api_url}users/user")
+              .to_raise(Faraday::ConnectionFailed.new('connection reset'))
+              .then.to_return(status: 200, body: '{}')
+
+    described_class.new.get_user(user_id: 'user')
+
+    expect(request).to have_been_requested.times(2)
+  end
+
+  it 'retries writes carrying an idempotency key' do
+    request = stub_request(:post, "#{api_url}users/user/actions/withdrawal")
+              .to_return({ status: 503, body: '{}' }, { status: 200, body: '{}' })
+
+    described_class.new.track(
+      user_id: 'user',
+      action: 'withdrawal',
+      attributes: { idempotency_key: 'key' }
+    )
+
+    expect(request).to have_been_requested.times(2)
+  end
+
+  it 'does not retry non-idempotent writes or 499 responses' do
+    post_request = stub_request(:post, "#{api_url}users/user/actions/withdrawal").to_return(status: 503, body: '{}')
+    challenge_request = stub_request(:get, "#{api_url}users/user").to_return(status: 499, body: '{}')
+    client = described_class.new
+
+    client.track(user_id: 'user', action: 'withdrawal', attributes: {})
+    client.get_user(user_id: 'user')
+
+    expect(post_request).to have_been_requested.once
+    expect(challenge_request).to have_been_requested.once
+  end
+
+  it 'allows retries to be disabled' do
+    Authsignal.configuration.retry = false
+    request = stub_request(:get, "#{api_url}users/user").to_return(status: 503, body: '{}')
+
+    described_class.new.get_user(user_id: 'user')
+
+    expect(request).to have_been_requested.once
+  end
+end


### PR DESCRIPTION
### New Features

- Enable retries by default for transient network errors, 429s, and 5xx responses
- Only retry safe or idempotent requests
- Add configurable retries, timeouts, and test coverage

### Checklist

- [x] Version bumped
- [ ] Documentation updated